### PR TITLE
Add capacity in dataset

### DIFF
--- a/deploy/crds/datastore.io_datasets_crd.yaml
+++ b/deploy/crds/datastore.io_datasets_crd.yaml
@@ -57,6 +57,9 @@ spec:
           spec:
             description: DataSetSpec defines the desired state of DataSet
             properties:
+              capacityBytes:
+                format: int64
+                type: integer
               ftp:
                 properties:
                   dir:

--- a/pkg/apis/datastore/v1alpha1/dataset_types.go
+++ b/pkg/apis/datastore/v1alpha1/dataset_types.go
@@ -24,6 +24,8 @@ type DataSetSpec struct {
 
 	FTP *FTPSpec `json:"ftp,omitempty"`
 
+	CapacityBytes int64 `json:"capacityBytes,omitempty"`
+
 	// indicate if refresh data or not
 	// +kubebuilder:default:=true
 	Refresh bool `json:"refresh"`

--- a/pkg/storage/minio/minio.go
+++ b/pkg/storage/minio/minio.go
@@ -229,7 +229,7 @@ func dfgetData(clientset kubernetes.Interface, spec *datastorev1alpha1.MinIOSpec
 	podClient := clientset.CoreV1().Pods(namespace)
 	pod, err := podClient.Get(context.TODO(), podName, metav1.GetOptions{})
 	if err != nil {
-		log.WithError(err).Error("Failed to get pod:%s", podName)
+		log.WithError(err).Errorf("Failed to get pod:%s", podName)
 		return err
 	}
 	genDir, err := findGenDirPath(pod, volumeName, clientset)

--- a/pkg/storage/minio/minio_api.go
+++ b/pkg/storage/minio/minio_api.go
@@ -1,0 +1,34 @@
+package minio
+
+import (
+	"context"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+type MC struct {
+	*minio.Client
+}
+
+func NewClientFor(endpoint, id, secret string, secure bool) (*MC, error) {
+	cli, err := minio.New(endpoint, &minio.Options{
+		Creds:  credentials.NewStaticV4(id, secret, ""),
+		Secure: secure,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &MC{cli}, nil
+}
+
+func (mc *MC) GetBucketCapacity(bucketName string) (int64, error) {
+	bucketSize := int64(0)
+	for object := range mc.ListObjects(context.TODO(), bucketName, minio.ListObjectsOptions{Recursive: true}) {
+		if object.Err != nil {
+			return bucketSize, object.Err
+		}
+		bucketSize += object.Size
+	}
+	return bucketSize, nil
+}

--- a/pkg/storage/minio/minio_api_test.go
+++ b/pkg/storage/minio/minio_api_test.go
@@ -1,0 +1,129 @@
+package minio
+
+import (
+	"context"
+	"github.com/minio/minio-go/v7"
+	_ "github.com/minio/minio-go/v7"
+	"os"
+	"strconv"
+	"testing"
+)
+
+const (
+	serverEndpoint = "SERVER_ENDPOINT"
+	accessKey      = "ACCESS_KEY"
+	secretKey      = "SECRET_KEY"
+	enableHTTPS    = "ENABLE_HTTPS"
+	enableKMS      = "ENABLE_KMS"
+)
+
+func TestNewClient(t *testing.T) {
+	mc, err := NewClientFor(os.Getenv(serverEndpoint), os.Getenv(accessKey), os.Getenv(secretKey), mustParseBool(os.Getenv(enableHTTPS)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("Client: %v is offline: %v", mc, mc.IsOffline())
+}
+
+func TestGetBucketCapacity(t *testing.T) {
+	testCases := []struct {
+		desc       string
+		bucketName string
+		objectName string
+		filePath   string
+		objectSize int64
+	}{
+		{
+			desc:       "get bucket capacity",
+			bucketName: "datastore-test-bucket",
+			objectName: "test.txt",
+			filePath:   "test.txt",
+			objectSize: 1024,
+		},
+	}
+
+	for _, testCase := range testCases {
+		mc, err := NewClientFor(os.Getenv(serverEndpoint), os.Getenv(accessKey), os.Getenv(secretKey), mustParseBool(os.Getenv(enableHTTPS)))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Run("parent", func(t *testing.T) {
+			if err = makeBucket(mc.Client, testCase.bucketName); err != nil {
+				t.Fatal(err)
+			}
+			if err = createFileWithSize(testCase.objectName, testCase.objectSize); err != nil {
+				t.Fatal(err)
+			}
+			if err = putObject(mc.Client, testCase.objectName, testCase.bucketName, testCase.filePath, "text/plain"); err != nil {
+				t.Fatal(err)
+			}
+
+			t.Run(testCase.desc, func(t *testing.T) {
+				capacity, err := mc.GetBucketCapacity(testCase.bucketName)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if capacity != testCase.objectSize {
+					t.Fatalf("expected %d, got %d", testCase.objectSize, capacity)
+				}
+			})
+		})
+	}
+}
+
+func makeBucket(mc *minio.Client, bucketName string) error {
+	err := mc.MakeBucket(context.TODO(), bucketName, minio.MakeBucketOptions{})
+	if err != nil {
+		exists, err := mc.BucketExists(context.TODO(), bucketName)
+		if err == nil && exists {
+			return nil
+		} else {
+			return err
+		}
+	}
+	return nil
+}
+
+func putObject(mc *minio.Client, objectName, bucketName, filePath, contentType string) error {
+	_, err := mc.FPutObject(context.TODO(), bucketName, objectName, filePath, minio.PutObjectOptions{ContentType: contentType})
+	return err
+}
+
+func createFileWithSize(filename string, size int64) error {
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	data := make([]byte, size)
+	_, err = file.Write(data)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func init() {
+	// If server endpoint is not set, all tests default to
+	// using https://play.min.io
+	if os.Getenv(serverEndpoint) == "" {
+		os.Setenv(serverEndpoint, "play.min.io")
+		os.Setenv(accessKey, "Q3AM3UQ867SPQQA43P2F")
+		os.Setenv(secretKey, "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+		os.Setenv(enableHTTPS, "1")
+	}
+}
+
+// Convert string to bool and always return false if any error
+func mustParseBool(str string) bool {
+	b, err := strconv.ParseBool(str)
+	if err != nil {
+		return false
+	}
+	return b
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,8 +3,12 @@ package utils
 import (
 	"crypto/md5"
 	"encoding/hex"
+	"fmt"
 	"io"
+	"math"
 	"os"
+	"strconv"
+	"unicode"
 
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
@@ -62,4 +66,100 @@ func IsStringInSet(str string, strArray []string) bool {
 		}
 	}
 	return false
+}
+
+var (
+	unitArray = []string{"B", "KB", "MB", "GB", "TB"}
+	unitMap   = map[string]int64{
+		"b":  1,
+		"B":  1,
+		"k":  1000,
+		"K":  1024,
+		"KB": 1024,
+		"m":  1000 * 1000,
+		"M":  1024 * 1024,
+		"MB": 1024 * 1024,
+		"g":  1000 * 1000 * 1000,
+		"G":  1024 * 1024 * 1024,
+		"GB": 1024 * 1024 * 1024,
+		"t":  1000 * 1000 * 1000 * 1000,
+		"T":  1024 * 1024 * 1024 * 1024,
+		"TB": 1024 * 1024 * 1024 * 1024,
+	}
+)
+
+// ParseBytes parse size from string into bytes
+func ParseBytes(sizeStr string) (int64, error) {
+	numStr := ""
+	unitStr := ""
+	for i := range sizeStr {
+		if !unicode.IsDigit(rune(sizeStr[i])) {
+			numStr = sizeStr[:i]
+			unitStr = sizeStr[i:]
+			break
+		} else {
+			numStr = sizeStr[:i+1]
+		}
+	}
+
+	if numStr == "" {
+		return -1, fmt.Errorf("wrong number: %s", sizeStr)
+	}
+	if unitStr == "" {
+		unitStr = "B"
+	}
+	multiple, has := unitMap[unitStr]
+	if !has {
+		return -1, fmt.Errorf("wrong unit: %s", sizeStr)
+	}
+
+	size, err := strconv.ParseInt(numStr, 10, 32)
+	if err != nil {
+		return -1, err
+	}
+	return size * multiple, nil
+}
+
+// ConvertBytesToStr convert size into string
+func ConvertBytesToStr(size int64) string {
+	unitIndex := 0
+	for size > 1024 {
+		size /= 1024
+		unitIndex++
+	}
+	return fmt.Sprintf("%d%s", size, unitArray[unitIndex])
+}
+
+// ConvertBytesToIEC converts bytes to IEC units (Ki, Mi, Gi, etc.) and rounds up
+func ConvertBytesToIEC(bytes uint64) string {
+	if bytes == 0 {
+		return "0"
+	}
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d", bytes)
+	}
+	exp := int(math.Log(float64(bytes)) / math.Log(unit))
+	pre := "KMGTPE"[exp-1]
+	value := math.Ceil(float64(bytes) / math.Pow(unit, float64(exp)))
+	return fmt.Sprintf("%.0f%ci", value, pre)
+}
+
+func CapacityRoundUp(originSize int64) int64 {
+	const unit = 1024
+	exp := int(math.Log(float64(originSize)) / math.Log(unit)) // "KMGTPE"
+	if exp > 3 {
+		return originSize
+	}
+
+	base := int64(1)
+	for i := 0; i < exp; i++ {
+		base *= 1024
+	}
+
+	if originSize%base == 0 {
+		return originSize
+	}
+
+	return ((originSize + base) / base) * base
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,74 @@
+package utils
+
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+	"testing"
+)
+
+func TestCapacityRoundUp(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		originalSize float64
+		expectedSize string
+	}{
+		{
+			desc:         "bytes to str 1KB",
+			originalSize: 1024,
+			expectedSize: "1Ki",
+		},
+		{
+			desc:         "bytes to str 1.7KB",
+			originalSize: 1.7 * 1024,
+			expectedSize: "2Ki",
+		},
+		{
+			desc:         "bytes to str 1MB",
+			originalSize: 1024 * 1024,
+			expectedSize: "1Mi",
+		},
+		{
+			desc:         "bytes to str 1.5MB",
+			originalSize: 1.5 * 1024 * 1024,
+			expectedSize: "2Mi",
+		},
+		{
+			desc:         "bytes to str 1GB",
+			originalSize: 1024 * 1024 * 1024,
+			expectedSize: "1Gi",
+		},
+		{
+			desc:         "bytes to str 1.3GB",
+			originalSize: 1.3 * 1024 * 1024 * 1024,
+			expectedSize: "2Gi",
+		},
+		{
+			desc:         "bytes to str 1023.8 GB",
+			originalSize: 1023.8 * 1024 * 1024 * 1024,
+			expectedSize: "1Ti",
+		},
+		{
+			desc:         "bytes to str 1TB",
+			originalSize: 1024 * 1024 * 1024 * 1024,
+			expectedSize: "1Ti",
+		},
+		{
+			desc:         "bytes to str 1.3TB - don't round up",
+			originalSize: 1.5 * 1024 * 1024 * 1024 * 1024,
+			expectedSize: "1536Gi",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.desc, func(t *testing.T) {
+			roundedCapacity := CapacityRoundUp(int64(testCase.originalSize))
+			if roundedCapacity != int64(testCase.originalSize) {
+				t.Logf("origin %d, roundedUp %d", int64(testCase.originalSize), roundedCapacity)
+			}
+
+			got := resource.NewQuantity(roundedCapacity, resource.BinarySI).String()
+			if got != testCase.expectedSize {
+				t.Fatalf("expected %s, got %s", testCase.expectedSize, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What's Changed

### For Dataset Instance:

`CapacityBytes` will be patched which fetched from configured backend storage when capacity is empty.

### For Cache LocalVolume

`LocalVolume`'s capacity will keep consistent with capacity in dataset.